### PR TITLE
Delete a part of configuration for Github Pages

### DIFF
--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -10,7 +10,4 @@ export default defineConfig({
     // You can change the port for starting up.
     port: 5173
   },
-  base: process.env.GITHUB_PAGES
-    ? "front"
-    : "./",
 })


### PR DESCRIPTION
## description
I deleted a part of configuration for Github Pages, because I changed how to deploy. The change is a Github Actions Workflow only deploys a HTML and CSS file, doesn't build. So, I should build React application at local before pushing to remote.